### PR TITLE
New release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Chart 0.3.7 [GitCall 2.8.2] - 2024-12-09
+### Helm changes
+- Applications versions:
+    - gitcall - 2.8.2
+- Fix for `HPA` gitcall
+- Update `valkey` up to `8 version`.
+- Refactor for initWait containers for `PostgreSQL`, `RabbitMQ` and `ValKey`
 
-## Chart 0.3.6 [GitCall 2.8.2] - 2024-10.29
+
+## Chart 0.3.6 [GitCall 2.8.2] - 2024-10-29
 ### Helm changes
 - Applications versions:
     - gitcall - 2.8.2
@@ -43,7 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Chart 0.3.0 [GitCall 2.7.2] - 2024-08-06
 ### Helm changes
-
 The following features have been added:
 - Kubernetes NetworkPolicy (to Helm).
 - ARM64 support.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,14 +3,14 @@ name: gitcall
 description: GitCall Helm Chart
 icon: https://media-exp1.licdn.com/dms/image/C4E0BAQG_mUmw1UsyuA/company-logo_200_200/0/1525514455224?e=2147483647&v=beta&t=Bmmfd3W25bG64i0R7wY7ZeuMRw7-Y6Xsh94N4nvpWFk
 type: application
-version: 0.3.6
+version: 0.3.7
 appVersion: 2.8.2
 dependencies:
   - name: gitcall
-    version: 0.3.1
+    version: 0.3.2
   - name: docker
     version: 0.1.2
   - name: registry
     version: 0.2.1
   - name: valkey-gitcall
-    version: 0.0.2
+    version: 0.0.3

--- a/charts/gitcall/Chart.yaml
+++ b/charts/gitcall/Chart.yaml
@@ -3,5 +3,5 @@ name: gitcall
 description: GitCall
 icon: https://media-exp1.licdn.com/dms/image/C4E0BAQG_mUmw1UsyuA/company-logo_200_200/0/1525514455224?e=2147483647&v=beta&t=Bmmfd3W25bG64i0R7wY7ZeuMRw7-Y6Xsh94N4nvpWFk
 kubeVersion: ">=1.19.0"
-version: 0.3.1
+version: 0.3.2
 appVersion: 2.8.2

--- a/charts/gitcall/templates/deployment.yaml
+++ b/charts/gitcall/templates/deployment.yaml
@@ -33,15 +33,9 @@ spec:
       terminationGracePeriodSeconds: 40
       serviceAccountName: gitcall-serviceaccount
       initContainers:
-        - name: init-wait-postgresql
-          image: {{ include "common.initContainers.image" . }}
-          command: [ "sh", "-c", "until nc -zvw1 {{ $pgCfg.dbhost }} {{ $pgCfg.dbport }}; do echo waiting for PostgreSQL dependencies; sleep 2; done;" ]
-        - name: init-wait-rabbitmq
-          image: {{ include "common.initContainers.image" . }}
-          command: [ "sh", "-c", "until nc -zvw1 {{ $mqCfg.host }} {{ $mqCfg.port }}; do echo waiting for RabbitMQ dependencies; sleep 2; done;" ]
-        - name: init-wait-valkey
-          image: {{ include "common.initContainers.image" . }}
-          command: [ "sh", "-c", "until nc -zvw1 {{ $valkeyCfg.host }} {{ $valkeyCfg.port }}; do echo waiting for ValKey dependencies; sleep 2; done;" ]
+        {{ include "GitcallInitWaitDatabase" . | nindent 8 | trim }}
+        {{ include "GitcallInitWaitRabbitMQ" . | nindent 8 | trim }}
+        {{ include "GitcallInitWaitValkey" . | nindent 8 | trim }}
       {{- if not (eq .Values.global.repotype "public") }}
       imagePullSecrets:
         - name: {{ .Values.global.imagePullSecrets.name }}

--- a/charts/gitcall/templates/hpa.yaml
+++ b/charts/gitcall/templates/hpa.yaml
@@ -9,7 +9,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "gitcall.fullname" . | quote }}
+    name: {{ include "common.Name" . }}-deployment
   minReplicas: {{ .Values.global.gitcall.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.global.gitcall.autoscaling.maxReplicas }}
   targetCPUUtilizationPercentage: {{ .Values.global.gitcall.autoscaling.targetCPUUtilizationPercentage }}

--- a/charts/valkey-gitcall/Chart.yaml
+++ b/charts/valkey-gitcall/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: valkey-gitcall
-version: 0.0.2
-appVersion: 7.2
+version: 0.0.3
+appVersion: 8
 description: The valkey single-node service.

--- a/charts/valkey-gitcall/values.yaml
+++ b/charts/valkey-gitcall/values.yaml
@@ -3,4 +3,4 @@ appPort: 6379
 image:
   registry: docker.io/valkey
   repository: /valkey
-  tag: "7.2-alpine"
+  tag: "8-alpine"

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -47,6 +47,10 @@ imagePullSecrets:
 {{ .Values.global.imageInit.repository }}:{{ .Values.global.imageInit.tag }}
 {{- end }}
 
+{{- define "common.initWait.image" -}}
+{{ .Values.global.imageInit.repository }}:{{ .Values.global.imageInit.tag }}
+{{- end -}}
+
 {{- define "gitcall.postgresSecretAnnotations" -}}
 {{ if .Values.global.gitcall.secret.postgres.annotations -}}
 {{ toYaml .Values.global.gitcall.secret.postgres.annotations }}

--- a/templates/kube.yaml
+++ b/templates/kube.yaml
@@ -1,5 +1,89 @@
-{{- define "CorezoidInitWaitRabbitMQResolve" -}}
-- name: init-wait-rabbit-resolve
+{{- define "GitcallInitWaitDatabase" -}}
+- name: init-wait-database-resolve
+  image: {{ include "common.initWait.image" . }}
+  imagePullPolicy: IfNotPresent
+  command: ["sh"]
+  args:
+    - "-c"
+    - |
+      if ! echo ${POSTGRES_DBHOST} | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+        until IP=$(nslookup ${POSTGRES_DBHOST} 2>/dev/null | grep "Address: " | sed 's/.*: //g;s/ .*//g'); [ -n "$IP" ]; do
+          echo "Waiting for Database IP resolution";
+          sleep 2;
+        done
+        echo "Resolved PostgreSQL (${POSTGRES_DBHOST}) to IP: $IP"
+      else
+        echo "${POSTGRES_DBHOST} is already an IP address, skipping resolution.";
+      fi
+  env:
+    - name: POSTGRES_DBHOST
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "gitcall.postgresSecretName" . }}
+          key: dbhost
+  terminationMessagePath: /dev/termination-log
+  terminationMessagePolicy: File
+
+- name: init-wait-database-port
+  image: {{ include "common.initWait.image" . }}
+  command: ["sh"]
+  args:
+    - "-c"
+    - |
+      until nc -zvw1 ${POSTGRES_DBHOST} ${POSTGRES_DBPORT};
+      do
+        echo "Waiting for Database port available";
+        sleep 2;
+      done;
+  env:
+    - name: POSTGRES_DBHOST
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "gitcall.postgresSecretName" . }}
+          key: dbhost
+    - name: POSTGRES_DBPORT
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "gitcall.postgresSecretName" . }}
+          key: dbport
+  terminationMessagePath: /dev/termination-log
+  terminationMessagePolicy: File
+
+- name: init-wait-database-gitcall
+  image: {{ .Values.global.db.image }}
+  imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
+  {{- if eq .Values.global.db.serverTlsSslenabled true }}
+  command: ["sh", "-c", "until PGPASSWORD=${POSTGRES_DBPWD} psql --set=sslmode={{ .Values.global.db.serverTlsSslmode }} -h ${POSTGRES_DBHOST} -U ${POSTGRES_DBUSER} -d ${GITCALL_DB} -c \"select 1\" > /dev/null 2>&1; do echo Waiting for ${GITCALL_DB} database; sleep 3; done;"]
+  {{- else }}
+  command: ["sh", "-c", "until PGPASSWORD=${POSTGRES_DBPWD} psql -h ${POSTGRES_DBHOST} -U ${POSTGRES_DBUSER} -d ${GITCALL_DB} -c \"select 1\" > /dev/null 2>&1; do echo Waiting for ${GITCALL_DB} database; sleep 3; done;"]
+  {{- end }}
+  env:
+    - name: POSTGRES_DBHOST
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "gitcall.postgresSecretName" . }}
+          key: dbhost
+    - name: POSTGRES_DBPORT
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "gitcall.postgresSecretName" . }}
+          key: dbport
+    - name: POSTGRES_DBUSER
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "gitcall.postgresSecretName" . }}
+          key: dbuser
+    - name: POSTGRES_DBPWD
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "gitcall.postgresSecretName" . }}
+          key: dbpwd
+    - name: GITCALL_DB
+      value: {{ .Values.global.gitcall.db_name | default "gitcall" }}
+{{- end -}}
+
+{{- define "GitcallInitWaitRabbitMQ" -}}
+- name: init-wait-rmq-resolve
   image: {{ include "common.initWait.image" . }}
   imagePullPolicy: IfNotPresent
   command: ["sh"]
@@ -11,6 +95,7 @@
           echo "Waiting for RabbitMQ IP resolution";
           sleep 2;
         done
+        echo "Resolved RabbitMQ (${MQ_HOST}) to IP: $IP"
       else
         echo "${MQ_HOST} is already an IP address, skipping resolution.";
       fi
@@ -18,16 +103,14 @@
     - name: MQ_HOST
       valueFrom:
         secretKeyRef:
-          name: {{ include "dbcall.rabbitSecretName" . }}
+          name: {{ include "gitcall.mqSecretName" . }}
           key: host
   terminationMessagePath: /dev/termination-log
   terminationMessagePolicy: File
-{{- end -}}
 
-{{- define "CorezoidInitWaitRabbitMQPort" -}}
 - name: init-wait-rmq-port
   image: {{ include "common.initWait.image" . }}
-  command: ['sh']
+  command: ["sh"]
   args:
     - "-c"
     - |
@@ -40,12 +123,64 @@
     - name: MQ_HOST
       valueFrom:
         secretKeyRef:
-          name: {{ include "dbcall.rabbitSecretName" . }}
+          name: {{ include "gitcall.mqSecretName" . }}
           key: host
     - name: MQ_PORT
       valueFrom:
         secretKeyRef:
-          name: {{ include "dbcall.rabbitSecretName" . }}
+          name: {{ include "gitcall.mqSecretName" . }}
+          key: port
+  terminationMessagePath: /dev/termination-log
+  terminationMessagePolicy: File
+{{- end -}}
+
+{{- define "GitcallInitWaitValkey" -}}
+- name: init-wait-valkey-resolve
+  image: {{ include "common.initWait.image" . }}
+  imagePullPolicy: IfNotPresent
+  command: ["sh"]
+  args:
+    - "-c"
+    - |
+      if ! echo ${VALKEY_HOST} | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+        until IP=$(nslookup ${VALKEY_HOST} 2>/dev/null | grep "Address: " | sed 's/.*: //g;s/ .*//g'); [ -n "$IP" ]; do
+          echo "Waiting for Redis IP resolution";
+          sleep 2;
+        done
+        echo "Resolved Valkey (${VALKEY_HOST}) to IP: $IP"
+      else
+        echo "${VALKEY_HOST} is already an IP address, skipping resolution.";
+      fi
+  env:
+    - name: VALKEY_HOST
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "gitcall.valkeySecretName" . }}
+          key: host
+  terminationMessagePath: /dev/termination-log
+  terminationMessagePolicy: File
+
+- name: init-wait-valkey-port
+  image: {{ include "common.initWait.image" . }}
+  command: ["sh"]
+  args:
+    - "-c"
+    - |
+      until nc -zvw1 ${VALKEY_HOST} ${VALKEY_PORT};
+      do
+        echo "Waiting for Valkey port available";
+        sleep 2;
+      done;
+  env:
+    - name: VALKEY_HOST
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "gitcall.valkeySecretName" . }}
+          key: host
+    - name: VALKEY_PORT
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "gitcall.valkeySecretName" . }}
           key: port
   terminationMessagePath: /dev/termination-log
   terminationMessagePolicy: File

--- a/values.yaml
+++ b/values.yaml
@@ -11,11 +11,11 @@ global:
   imageInit:
     repository: hub.corezoid.com/hub.docker.com/library/alpine
     pullPolicy: IfNotPresent
-    tag: "3.20"
+    tag: "3.21"
   alpineImage:
     registry: hub.corezoid.com
     repository: hub.docker.com/library/alpine
-    tag: "3.20"
+    tag: "3.21"
   serviceMonitor:
     enabled: true
   dashboards:
@@ -42,6 +42,7 @@ global:
     annotations:
       ingress.class: internal-nginx
   db:
+    image: "postgres:16-alpine"
     # if internal true - create and use internal postgres container
     # if internal false - enable external db, like aws rds
     internal: false


### PR DESCRIPTION
## Chart 0.3.7 [GitCall 2.8.2]
### Helm changes
- Applications versions:
    - gitcall - 2.8.2
- Fix for `HPA` gitcall
- Update `valkey` up to `8 version`.
- Refactor for initWait containers for `PostgreSQL`, `RabbitMQ` and `ValKey`